### PR TITLE
Fix non-TTY crash in config:*, db.prefix YAML, and missing PHP memory_limit

### DIFF
--- a/dev/docker-compose.yml.js
+++ b/dev/docker-compose.yml.js
@@ -34,7 +34,7 @@ services:
       WORDPRESS_DB_NAME: wordpress
       WORDPRESS_DB_USER: wordpress
       WORDPRESS_DB_PASSWORD: wordpress${
-        settings?.db?.prefix ? `      WORDPRESS_DB_PREFIX: ${settings?.db?.prefix}` : ''
+        settings?.db?.prefix ? `\n      WORDPRESS_DB_PREFIX: ${settings?.db?.prefix}` : ''
       }
       WORDPRESS_DEBUG: 'true'
       # When behind the Portless proxy, trust its forwarded headers so WordPress uses the real public host/scheme instead of the internal 127.0.0.1 backend address

--- a/dev/provision/wp/zz-php.ini
+++ b/dev/provision/wp/zz-php.ini
@@ -1,4 +1,5 @@
 max_execution_time=300
+memory_limit=512M
 upload_max_filesize=32M
 log_errors=On
 error_log=/dev/stderr

--- a/index.js
+++ b/index.js
@@ -50,11 +50,15 @@ const wait = (message, callback, delay=500) => {
 				resolve(response);
 			};
 		handler = setInterval(() => {
-			// move cursor to beginning of line
-			process.stdout.clearLine();
-			process.stdout.cursorTo(0);
-			// write with no line change
-			process.stdout.write(`\x1b[7m[FDK]\x1b[27m ${spinner[waitcounter % 12]}  ${message}`);
+			// clearLine/cursorTo only exist on a TTY; in a non-TTY shell (pipe, CI,
+			// agent) calling them throws and aborts the command mid-run
+			if (process.stdout.isTTY) {
+				// move cursor to beginning of line
+				process.stdout.clearLine();
+				process.stdout.cursorTo(0);
+				// write with no line change
+				process.stdout.write(`\x1b[7m[FDK]\x1b[27m ${spinner[waitcounter % 12]}  ${message}`);
+			}
 			callback(stopWaitInterval);
 			waitcounter++;
 			// send callback a closure to stop the interval timer


### PR DESCRIPTION
Context: rolled Portless (`use: [portless]`) across all 14 of our live local projects on FDK 3.2. It works well; these are the rough edges we hit doing it. Split into two PRs so the safe fixes aren't blocked behind the behaviour change.

Independent one-liners; none change behaviour for a working project.

### 1. `config:*` crashes fatally in a non-TTY shell
`wait()`'s spinner calls `process.stdout.clearLine()` / `.cursorTo()`, which only exist on
a TTY. In a pipe, CI, or an AI agent shell they throw
`TypeError: process.stdout.clearLine is not a function` — and it's **not cosmetic**: it
kills the command part-way. `config:all` dies *before* `configURL` runs, so the alias and
DB URL rewrite silently never happen, while the resource/volume step looks like it
succeeded. Fix: guard the cursor calls behind `if (process.stdout.isTTY)`.

### 2. `db.prefix` generates invalid YAML at `fdk setup`
`dev/docker-compose.yml.js` interpolates `WORDPRESS_DB_PREFIX` with no preceding newline:

```
WORDPRESS_DB_PASSWORD: wordpress      WORDPRESS_DB_PREFIX: zz_   # one line -> won't parse
```

Any new project with `db.prefix` set produces a compose file that fails to load. Fix: add
`\n` to the interpolated fragment. (Pre-existing, traces back to `1902218`; latent because
nothing currently sets `db.prefix`.)

### 3. No `memory_limit` in the PHP template
`dev/provision/wp/zz-php.ini` sets no `memory_limit`, so every project inherits PHP's 128M
default. A heavy stack (WooCommerce + Subscriptions + Jetpack + WC Blocks) exhausts it
during WP-CLI bootstrap — the frontend survives because it never loads the whole stack,
but `wp` fatals, which (via bug 1's failure mode) silently no-ops any `config:url`. The
fatal's backtrace points at whatever class was loading when memory ran out (looked like a
Jetpack/PHP 8.4 incompatibility; it wasn't). Fix: `memory_limit=512M` in the template.

**Verification:** template renders + parses with and without `db.prefix`; `node --check`
on both files; spinner path exercised in a piped shell.

---

### Considered and deliberately left out

- **Multisite** — 3.2 already removed it; no project used it.
- **Historical port cruft** in DBs (old dead ports in Yoast/WooCommerce caches, and
  `wp_posts.guid`). Pre-existing, self-regenerating, and `guid` must never be rewritten.
  Left alone.
- **`search-replace` scheme/encoding gaps** — `config:url` only matches the exact old
  siteURL with its stored protocol, so it misses the other scheme (`https://` vs `http://`)
  and JSON/serialised-escaped URLs in transients. We cleaned these up by hand per project;
  not worth a code change, but noting it.
