### PR TITLE
Auto-migrate existing projects to Portless header trust

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,6 +75,16 @@ checkDependencies();
 // Check if portless CLI is available
 const checkPortless = () => sh.exec('hash portless 2>/dev/null', { silent: true }).code === 0;
 
+// When behind the Portless proxy, WordPress must trust its forwarded headers so it uses
+// the real public host/scheme instead of the internal 127.0.0.1 backend address. This
+// ships in the setup template for new projects; `configServices` injects it into existing
+// projects. `$$` escapes Docker Compose interpolation so the container receives `$_SERVER`.
+const PORTLESS_CONFIG_EXTRA = `if (!empty($$_SERVER['HTTP_X_PORTLESS_HOPS'])) {
+	if (!empty($$_SERVER['HTTP_X_FORWARDED_HOST'])) $$_SERVER['HTTP_HOST'] = $$_SERVER['HTTP_X_FORWARDED_HOST'];
+	if (($$_SERVER['HTTP_X_FORWARDED_PROTO'] ?? '') === 'https') $$_SERVER['HTTPS'] = 'on';
+}
+`;
+
 const getSetupPackageManager = (settings) => {
 	let packageManager = '';
 
@@ -584,6 +594,18 @@ const configURL = async () => {
 // Check if there are any new services to add to `docker-compose.yml`
 const configServices = (projectConfig, dockerConfig) => {
 	let needsRestart = false;
+
+	// Portless: migrate existing projects by injecting the forwarded-header trust snippet
+	// into the wp container. Without it WordPress canonicalises to the internal backend
+	// address (301 -> https://127.0.0.1/). Flagging needsRestart recreates wp so the env lands.
+	const usePortless = projectConfig?.use?.indexOf('portless') >= 0;
+	if (usePortless && dockerConfig.services?.wp) {
+		dockerConfig.services.wp.environment ||= {};
+		if (dockerConfig.services.wp.environment.WORDPRESS_CONFIG_EXTRA !== PORTLESS_CONFIG_EXTRA) {
+			needsRestart = true;
+			dockerConfig.services.wp.environment.WORDPRESS_CONFIG_EXTRA = PORTLESS_CONFIG_EXTRA;
+		}
+	}
 
 	// Mailpit
 	const useMailpit = projectConfig?.use?.indexOf('mailpit') >= 0,


### PR DESCRIPTION
Context: rolled Portless (`use: [portless]`) across all 14 of our live local projects on FDK 3.2. It works well; these are the rough edges we hit doing it. Split into two PRs so the safe fixes aren't blocked behind the behaviour change.

### The gap
`WORDPRESS_CONFIG_EXTRA` (the forwarded-header trust that stops WP canonicalising to the
internal `127.0.0.1` backend) ships in the **setup template**, so new projects get it for
free. But `config:*` *mutates* an existing `docker-compose.yml` rather than regenerating
it, so **every project created before 3.2 never receives it** — you enable
`use: [portless]`, `config:all` reports success, and the site 301s to
`https://127.0.0.1/`. On top of that, `config:*` only recreates the `wp` container when
resource volumes changed, so even after a manual compose edit the env doesn't land until a
force-recreate.

We hand-patched all 14 live projects for the rollout. This PR removes that manual step for
anyone else.

### The change
One block in `configServices()`: when `portless` is in the `use:` array and the `wp`
service's `WORDPRESS_CONFIG_EXTRA` doesn't already match, inject it and flag
`needsRestart`. Because `config:all` runs `configResources().then(configURL)`, the existing
`needsRestart` path writes the compose file and runs `docker compose up -d` (recreating
`wp` with the env), then `configURL` picks up the new port and rewrites the DB. So one
insertion closes both halves — inject *and* recreate — with no new control flow.

The injected constant is defined once and is byte-identical to what the setup template
produces, so a migrated project and a fresh one converge on the same value.

### Verification (real project, `ukjf`, end-to-end)
1. Stripped `WORDPRESS_CONFIG_EXTRA` from its compose file to simulate a pre-3.2 project.
2. `fdk config:all` → injected the env, recreated `wp` (container received literal
   `$_SERVER`, i.e. `$$` de-escaped correctly), registered the alias, rewrote the DB.
   `https://ukjf.localhost/` → `200`, no redirect. Zero manual editing.
3. Second `fdk config:all` → **0 recreates** (idempotent), site still `200`.
4. Confirmed `PORTLESS_CONFIG_EXTRA === template output` and stable across a
   `yaml.dump → yaml.load` round-trip (no restart loop).

### Notes / possible pushback
- Assumes `wp.environment` is a **map**, consistent with the template and the existing
  mailpit/phpunit code in the same function. A project using list-form `environment:`
  wouldn't be handled — none of ours do.
- It will recreate the `wp` container the first time you run `config:*` on an existing
  portless project after upgrading. That's the intended migration, but it's a container
  restart people may not expect from `config:resources`.
