### PR TITLE
Stop deploys reverting acf-json edited in wp-admin

### DIFF
--- a/index.js
+++ b/index.js
@@ -780,12 +780,30 @@ const acfGroupsAheadOnRemote = (remoteDir, localDir) => {
 	});
 };
 
+// Pull the server's `acf-json` into `dest` before mirroring over it. Returns `true` if a copy
+// arrived, `false` if the server holds none yet, `null` if the pull itself failed: `lftp` exits
+// non-zero both for a folder that isn't there and for a transfer that broke, and only the first
+// is safe to read as 'nothing on the server to lose'
+const pullRemoteAcfJson = (commands, remotePath, dest) => {
+	const mirror = `mirror --verbose=0 ${remotePath} ${dest}`,
+		// force English so the 'folder isn't there' message can be told apart from a real failure
+		result = spawnSync('lftp', ['-c', [...commands, mirror].join('; ') + '; '], { stdio: ['inherit', 'inherit', 'pipe'], env: { ...process.env, LC_ALL: 'C' } }),
+		stderr = (result.stderr || '').toString();
+	// an empty or missing `dest` after a clean run means the folder is there but has nothing in it
+	if (result.status === 0) { return sh.test('-d', dest); }
+	if (!sh.test('-d', dest) && /No such file or directory/.test(stderr)) { return false; }
+	process.stderr.write(stderr);
+	return null;
+};
+
 // Files git would lose track of if they were overwritten in place. `files` are paths
 // relative to the repository root; null means there's no repository to ask
 const uncommittedFiles = (repoPath, files) => {
-	if (sh.exec(`git -C ${repoPath} rev-parse --is-inside-work-tree`, { silent: true }).code !== 0) { return null; }
+	const git = args => sh.exec(`git -C '${repoPath}' ${args}`, { silent: true });
+	if (git('rev-parse --is-inside-work-tree').code !== 0) { return null; }
 	return files.filter(file => {
-		const status = sh.exec(`git -C ${repoPath} status --porcelain -- ${file}`, { silent: true });
+		// asked one file at a time, so an empty answer means clean with no paths to parse back
+		const status = git(`status --porcelain -- '${file}'`);
 		// if git can't answer, assume there's something to lose
 		return status.code !== 0 || status.stdout.trim() !== '';
 	});
@@ -819,6 +837,9 @@ const deploy = (project='default', options) => {
 			warn('Settings for FTP upload not found');
 			return;
 		}
+
+		// resources whose upload was called off: the run mustn't report success without them
+		const skipped = [];
 		['themes', 'plugins'].forEach(resourceType => {
 			const resources = projectConfig[resourceType];
 			if (!resources) { return; }
@@ -826,6 +847,7 @@ const deploy = (project='default', options) => {
 				const name = resource.replace(/\/$/, '').split('/').pop();
 				if (!sh.test('-d', resource)) {
 					warn(`Path for resource '${name}' not found`);
+					skipped.push(name);
 					continue;
 				}
 				echo(`Deploying resource '${name}' to '${ftp.host}'...`);
@@ -849,9 +871,15 @@ const deploy = (project='default', options) => {
 				if (!options.force && sh.test('-d', acfPath)) {
 					const remoteCopy = path.join(sh.tempdir(), `fdk-acf-${name}`);
 					sh.rm('-rf', remoteCopy);
-					spawn(['lftp', '-c', [...commands, `mirror --verbose=0 ${path.join(destPath, name, 'acf-json')} ${remoteCopy}`].join('; ') + '; ']);
-					// no remote copy yet (first deploy): nothing to lose, carry on
-					const ahead = sh.test('-d', remoteCopy) ? acfGroupsAheadOnRemote(remoteCopy, acfPath) : [];
+					const pulled = pullRemoteAcfJson(commands, path.join(destPath, name, 'acf-json'), remoteCopy);
+					if (pulled === null) {
+						sh.rm('-rf', remoteCopy);
+						skipped.push(name);
+						warn(`Couldn't read the 'acf-json' folder of '${name}' from the server, so there's no telling whether it holds field groups this deploy would revert. Deploy of '${name}' stopped: fix the error above and deploy again, or re-run with '--force' to deploy regardless.`);
+						continue;
+					}
+					// nothing on the server yet (first deploy): nothing to lose, carry on
+					const ahead = pulled ? acfGroupsAheadOnRemote(remoteCopy, acfPath) : [];
 					if (ahead.length > 0) {
 						const listed = ahead.map(file => `  acf-json/${file}`).join('\n');
 						// bring them into the working tree so they can be reviewed and committed, but
@@ -863,8 +891,9 @@ const deploy = (project='default', options) => {
 							warn(`Server holds newer '${name}' field groups than this repo, most likely edited in wp-admin:\n${listed}\n\nPulling them would overwrite uncommitted local changes. Commit or stash these first, then deploy again:\n${uncommitted.map(file => `  ${file}`).join('\n')}`);
 						} else {
 							ahead.forEach(file => sh.cp('-f', path.join(remoteCopy, file), path.join(acfPath, file)));
-							warn(`Server holds newer '${name}' field groups than this repo, most likely edited in wp-admin. Deploy stopped, and they have been pulled into the working tree:\n${listed}\n\nReview and commit them, then deploy again — or 'git restore' them and re-run with '--force' to overwrite the server.`);
+							warn(`Server holds newer '${name}' field groups than this repo, most likely edited in wp-admin. Deploy of '${name}' stopped, and they have been pulled into the working tree:\n${listed}\n\nReview and commit them, then deploy again — or 'git restore' them and re-run with '--force' to overwrite the server.`);
 						}
+						skipped.push(name);
 						sh.rm('-rf', remoteCopy);
 						continue;
 					}
@@ -887,7 +916,14 @@ const deploy = (project='default', options) => {
 				spawn(['lftp', '-c', commands.join('; ') + '; ']);
 			}
 		});
+
+		if (skipped.length > 0) {
+			// non-zero exit, so a scripted deploy can't read a called-off resource as a clean run
+			process.exitCode = 1;
+			warn(`Deploy incomplete — not uploaded: ${skipped.join(', ')}`);
+		}
 	} catch (ex) {
+		process.exitCode = 1;
 		warn('Error deploying: ' + ex);
 	}
 }

--- a/index.js
+++ b/index.js
@@ -789,11 +789,16 @@ const pullRemoteAcfJson = (commands, remotePath, dest) => {
 		// force English so the 'folder isn't there' message can be told apart from a real failure
 		result = spawnSync('lftp', ['-c', [...commands, mirror].join('; ') + '; '], { stdio: ['inherit', 'inherit', 'pipe'], env: { ...process.env, LC_ALL: 'C' } }),
 		stderr = (result.stderr || '').toString();
-	// an empty or missing `dest` after a clean run means the folder is there but has nothing in it
+	// a clean run creates `dest` even when the remote folder held nothing, and an empty copy
+	// yields no groups ahead, so both read the same downstream
 	if (result.status === 0) { return sh.test('-d', dest); }
-	// sftp reports a missing folder as `Access failed: No such file (<path>)`, plain ftp as
-	// `550 ...: No such file or directory` — match the half both share
-	if (!sh.test('-d', dest) && /No such file/.test(stderr)) { return false; }
+	// `lftp` prefixes every couldn't-get-at-the-target error with `Access failed:` and then quotes
+	// the source verbatim, so match its own wrapper rather than the wording underneath: sftp says
+	// `No such file (<path>)`, `file://` says `<path>: No such file or directory`, and an FTP
+	// server says what it likes after its 550 — pure-ftpd `Can't change directory to ...: No such
+	// file or directory`, vsftpd merely `Failed to change directory.`. A pull that broke reads
+	// differently again (`Fatal error:`, `Login failed:`), so it still falls through to `null`
+	if (!sh.test('-d', dest) && /Access failed: (550 |.*No such file)/.test(stderr)) { return false; }
 	process.stderr.write(stderr);
 	return null;
 };

--- a/index.js
+++ b/index.js
@@ -762,6 +762,35 @@ const buildResources = (project='default', task='build') => {
 	}
 }
 
+// Field groups the server holds a newer revision of, judged by ACF's own `modified` stamp.
+// Local being newer, or present only locally, is just an ordinary edit on its way up
+const acfGroupsAheadOnRemote = (remoteDir, localDir) => {
+	const modifiedStamp = file => {
+		if (!sh.test('-f', file)) { return null; }
+		try {
+			return JSON.parse(sh.cat(file).toString()).modified || 0;
+		} catch (ex) {
+			return 0;
+		}
+	};
+	return sh.ls(remoteDir).filter(file => {
+		if (!file.endsWith('.json')) { return false; }
+		const local = modifiedStamp(path.join(localDir, file));
+		return local === null || modifiedStamp(path.join(remoteDir, file)) > local;
+	});
+};
+
+// Files git would lose track of if they were overwritten in place. `files` are paths
+// relative to the repository root; null means there's no repository to ask
+const uncommittedFiles = (repoPath, files) => {
+	if (sh.exec(`git -C ${repoPath} rev-parse --is-inside-work-tree`, { silent: true }).code !== 0) { return null; }
+	return files.filter(file => {
+		const status = sh.exec(`git -C ${repoPath} status --porcelain -- ${file}`, { silent: true });
+		// if git can't answer, assume there's something to lose
+		return status.code !== 0 || status.stdout.trim() !== '';
+	});
+};
+
 // Upload resources built files to server
 const deploy = (project='default', options) => {
 	const buildIgnoreParams = (distignore) => {
@@ -813,6 +842,34 @@ const deploy = (project='default', options) => {
 
 				// open command
 				commands.push(`open ${url}`);
+
+				// ACF saves field groups edited in wp-admin into the deployed resource's own
+				// `acf-json`, so mirroring over it silently reverts them: check before uploading
+				const acfPath = path.join(resource, 'acf-json');
+				if (!options.force && sh.test('-d', acfPath)) {
+					const remoteCopy = path.join(sh.tempdir(), `fdk-acf-${name}`);
+					sh.rm('-rf', remoteCopy);
+					spawn(['lftp', '-c', [...commands, `mirror --verbose=0 ${path.join(destPath, name, 'acf-json')} ${remoteCopy}`].join('; ') + '; ']);
+					// no remote copy yet (first deploy): nothing to lose, carry on
+					const ahead = sh.test('-d', remoteCopy) ? acfGroupsAheadOnRemote(remoteCopy, acfPath) : [];
+					if (ahead.length > 0) {
+						const listed = ahead.map(file => `  acf-json/${file}`).join('\n');
+						// bring them into the working tree so they can be reviewed and committed, but
+						// only where git can undo it and there's no local work to overwrite
+						const uncommitted = uncommittedFiles(resource, ahead.map(file => path.join('acf-json', file)));
+						if (uncommitted === null) {
+							warn(`Server holds newer '${name}' field groups than this repo, most likely edited in wp-admin. Deploying would revert them:\n${listed}\n\n'${name}' isn't a git repository, so they can't be pulled safely. Copy them across by hand, or re-run with '--force' to overwrite the server.`);
+						} else if (uncommitted.length > 0) {
+							warn(`Server holds newer '${name}' field groups than this repo, most likely edited in wp-admin:\n${listed}\n\nPulling them would overwrite uncommitted local changes. Commit or stash these first, then deploy again:\n${uncommitted.map(file => `  ${file}`).join('\n')}`);
+						} else {
+							ahead.forEach(file => sh.cp('-f', path.join(remoteCopy, file), path.join(acfPath, file)));
+							warn(`Server holds newer '${name}' field groups than this repo, most likely edited in wp-admin. Deploy stopped, and they have been pulled into the working tree:\n${listed}\n\nReview and commit them, then deploy again — or 'git restore' them and re-run with '--force' to overwrite the server.`);
+						}
+						sh.rm('-rf', remoteCopy);
+						continue;
+					}
+					sh.rm('-rf', remoteCopy);
+				}
 
 				if (options.backup) {
 					// copy old folder
@@ -918,6 +975,7 @@ const addProjectCommands = () => {
 		program.command('deploy [project]')
 			.description(`Deploy resources to server according to configuration in 'config.yml' file. If no <project> is passed, settings under 'default' will be loaded. Files and folders matching patterns in resource '.distignore' file will be ignored`)
 			.option('-k, --backup', 'backup existing resources folders before updating')
+			.option('-f, --force', `deploy even if the remote 'acf-json' has diverged from the local one`)
 			.action(deploy);
 	}
 	addScriptCommands();

--- a/index.js
+++ b/index.js
@@ -791,7 +791,9 @@ const pullRemoteAcfJson = (commands, remotePath, dest) => {
 		stderr = (result.stderr || '').toString();
 	// an empty or missing `dest` after a clean run means the folder is there but has nothing in it
 	if (result.status === 0) { return sh.test('-d', dest); }
-	if (!sh.test('-d', dest) && /No such file or directory/.test(stderr)) { return false; }
+	// sftp reports a missing folder as `Access failed: No such file (<path>)`, plain ftp as
+	// `550 ...: No such file or directory` — match the half both share
+	if (!sh.test('-d', dest) && /No such file/.test(stderr)) { return false; }
 	process.stderr.write(stderr);
 	return null;
 };

--- a/test/acf-json-guard.md
+++ b/test/acf-json-guard.md
@@ -1,6 +1,6 @@
 # Verifying the `acf-json` deploy guard
 
-Manual procedure for the check added in #58. It builds a throwaway resource and deploys it into a
+Manual procedure for the check on this branch. It builds a throwaway resource and deploys it into a
 scratch directory on a server, so no real site or theme is involved at any point. Runnable by hand or
 by an agent — each case states the exact command and the exact expected outcome.
 
@@ -18,6 +18,9 @@ Allow about ten minutes.
 Nothing here needs shell access on the server. Every "the server is ahead" state is produced by
 deploying a newer file and then rewinding the local copy, which is also how the original bug
 happened.
+
+Every case checks the exit status as well as the output: a stopped resource must not let the run
+report success.
 
 ## Setup
 
@@ -62,28 +65,31 @@ git init -q && git add -A && git commit -q -m seed
 ```
 
 Run every `fdk deploy` below from `/tmp/guard-test/proj`. Outside a project directory `fdk` doesn't
-register the `deploy` command at all, and `--force` fails with `unknown option`.
+register the `deploy` command at all — `--force` fails with `unknown option`, and a bare
+`fdk deploy` prints the general help and still exits 0, so it is easy to mistake for a pass.
 
 ## The cases
 
 ### 1. No remote `acf-json` yet
 
-First deploy, nothing on the server to lose.
+First deploy of a new resource: the server has no `acf-json` folder, so there is nothing to lose.
+This is the case that must not be confused with a failed read.
 
 ```bash
-fdk deploy
+fdk deploy; echo "EXIT=$?"
 ```
 
-**Expect:** both files transfer. No warning. In particular no `Access failed: No such file` — the
-pre-flight is silenced precisely so a first deploy doesn't look like a failure.
+**Expect:** both files transfer, `EXIT=0`, and no warning. In particular no
+`Access failed: No such file` — that message is the server saying the folder isn't there, which is
+expected here and is swallowed deliberately.
 
 ### 2. In sync
 
 ```bash
-fdk deploy
+fdk deploy; echo "EXIT=$?"
 ```
 
-**Expect:** the `Deploying resource` line and nothing else.
+**Expect:** the `Deploying resource` line, `EXIT=0`, nothing else.
 
 ### 3. Local newer — the everyday case
 
@@ -93,10 +99,10 @@ The one that must not be blocked: a field group edited locally, on its way up.
 cd /tmp/guard-test/guard-theme
 printf '{"key":"group_alpha","title":"Alpha","fields":[],"modified":2000}\n' > acf-json/group_alpha.json
 git commit -qam "local edit"
-cd /tmp/guard-test/proj && fdk deploy
+cd /tmp/guard-test/proj && fdk deploy; echo "EXIT=$?"
 ```
 
-**Expect:** `group_alpha.json` transfers. No warning.
+**Expect:** `group_alpha.json` transfers, `EXIT=0`, no warning.
 
 ### 4. Server newer, working tree clean
 
@@ -108,15 +114,15 @@ cd /tmp/guard-test/guard-theme
 printf '{"key":"group_alpha","title":"Alpha","fields":[],"modified":1000}\n' > acf-json/group_alpha.json
 git commit -qam rewind
 git status --short          # must be empty
-cd /tmp/guard-test/proj && fdk deploy
+cd /tmp/guard-test/proj && fdk deploy; echo "EXIT=$?"
 ```
 
-**Expect:** deploy stops, naming `acf-json/group_alpha.json`, saying it has been pulled into the
-working tree. Then:
+**Expect:** the deploy of `guard-theme` stops, naming `acf-json/group_alpha.json` as pulled into the
+working tree, followed by `Deploy incomplete — not uploaded: guard-theme` and `EXIT=1`. Then:
 
 ```bash
 cd /tmp/guard-test/guard-theme
-git status --short                              # ` M acf-json/group_alpha.json`
+git status --short                                      # ` M acf-json/group_alpha.json`
 grep -o '"modified":[0-9]*' acf-json/group_alpha.json   # `"modified":2000`
 ```
 
@@ -130,11 +136,11 @@ The refusal case: pulling would destroy uncommitted local work.
 ```bash
 cd /tmp/guard-test/guard-theme
 printf '{"key":"group_alpha","title":"Alpha","fields":[],"modified":1500}\n' > acf-json/group_alpha.json
-cd /tmp/guard-test/proj && fdk deploy
+cd /tmp/guard-test/proj && fdk deploy; echo "EXIT=$?"
 ```
 
-**Expect:** deploy stops with `Pulling them would overwrite uncommitted local changes`, naming the
-file, and:
+**Expect:** stops with `Pulling them would overwrite uncommitted local changes`, naming the file,
+then `Deploy incomplete` and `EXIT=1`. And:
 
 ```bash
 grep -o '"modified":[0-9]*' /tmp/guard-test/guard-theme/acf-json/group_alpha.json   # still 1500
@@ -147,10 +153,10 @@ destroyed local work — that is the serious failure mode for this feature.
 
 ```bash
 cd /tmp/guard-test/guard-theme && git restore acf-json/group_alpha.json
-cd /tmp/guard-test/proj && fdk deploy --force
+cd /tmp/guard-test/proj && fdk deploy --force; echo "EXIT=$?"
 ```
 
-**Expect:** `group_alpha.json` transfers, overwriting the newer server copy. No warning.
+**Expect:** `group_alpha.json` transfers, overwriting the newer server copy. `EXIT=0`, no warning.
 
 ### 7. A group that exists only on the server
 
@@ -159,10 +165,10 @@ Stands in for a field group created in production wp-admin that the repo has nev
 ```bash
 cd /tmp/guard-test/guard-theme
 git rm -q acf-json/group_beta.json && git commit -qm "drop beta locally"
-cd /tmp/guard-test/proj && fdk deploy
+cd /tmp/guard-test/proj && fdk deploy; echo "EXIT=$?"
 ```
 
-**Expect:** deploy stops, naming `acf-json/group_beta.json` as pulled. Then:
+**Expect:** stops, naming `acf-json/group_beta.json` as pulled, `EXIT=1`. Then:
 
 ```bash
 cd /tmp/guard-test/guard-theme && git status --short   # `?? acf-json/group_beta.json`
@@ -170,6 +176,22 @@ cd /tmp/guard-test/guard-theme && git status --short   # `?? acf-json/group_beta
 
 It comes back as an untracked file rather than a modification, which is correct — the repo never had
 it.
+
+### 8. The server can't be read at all
+
+A broken connection must not be read as "no field groups on the server", because that would deploy
+straight over the thing the check exists to protect.
+
+```bash
+cd /tmp/guard-test/proj
+sed 's/<your host>/nonexistent.invalid/' config.yml > config.bad.yml
+cp config.yml config.good.yml && cp config.bad.yml config.yml
+fdk deploy; echo "EXIT=$?"
+cp config.good.yml config.yml
+```
+
+**Expect:** the underlying `lftp` error is printed, then `Couldn't read the 'acf-json' folder`,
+`Deploy incomplete — not uploaded: guard-theme`, and `EXIT=1`. Nothing is uploaded.
 
 ## Teardown
 

--- a/test/acf-json-guard.md
+++ b/test/acf-json-guard.md
@@ -80,8 +80,12 @@ fdk deploy; echo "EXIT=$?"
 ```
 
 **Expect:** both files transfer, `EXIT=0`, and no warning. In particular no
-`Access failed: No such file` — that message is the server saying the folder isn't there, which is
-expected here and is swallowed deliberately.
+`Access failed: ...` — that message is the server saying the folder isn't there, which is expected
+here and is swallowed deliberately. Its wording is the server's own, so it varies with the target:
+sftp says `No such file (<path>)`, pure-ftpd `550 Can't change directory to ...: No such file or
+directory`, vsftpd merely `550 Failed to change directory.`. The check keys off `lftp`'s own
+`Access failed:` prefix for that reason, so this case is worth re-running against a second kind of
+server if you have one.
 
 ### 2. In sync
 

--- a/test/acf-json-guard.md
+++ b/test/acf-json-guard.md
@@ -1,0 +1,197 @@
+# Verifying the `acf-json` deploy guard
+
+Manual procedure for the check added in #58. It builds a throwaway resource and deploys it into a
+scratch directory on a server, so no real site or theme is involved at any point. Runnable by hand or
+by an agent — each case states the exact command and the exact expected outcome.
+
+Allow about ten minutes.
+
+## What you need
+
+- `lftp`, and this branch of FDK linked as your `fdk` binary (`npm link` in the repo, or run
+  `node /path/to/index.js` in place of `fdk` throughout).
+- A deploy target you can write a scratch directory to: any FTP/SFTP account you already use. It
+  never touches WordPress — the files land in a directory nothing reads. Copy the `ftp:` block from
+  one of your own `config.yml` files and change only `path`.
+- `git`.
+
+Nothing here needs shell access on the server. Every "the server is ahead" state is produced by
+deploying a newer file and then rewinding the local copy, which is also how the original bug
+happened.
+
+## Setup
+
+Two directories: a stub FDK project, and a git repo standing in for a theme.
+
+```bash
+mkdir -p /tmp/guard-test/proj /tmp/guard-test/guard-theme/acf-json
+cd /tmp/guard-test/proj
+touch .setup.yml docker-compose.yml
+printf '{"name":"guardtest","description":"acf-json guard harness","scripts":{}}\n' > package.json
+```
+
+`config.yml`, with the `ftp:` block replaced by your own and `path` pointing somewhere disposable:
+
+```yaml
+default:
+  themes:
+    - ../guard-theme
+  ftp:
+    user: <your user>
+    password: "<your password>"
+    host: <your host>
+    scheme: "sftp"
+    port: "18765"
+    path: "/home/customer/www/<a site you control>/tmp-fdk-guard-test"
+    params: [--delete]
+    commands:
+      - set sftp:auto-confirm yes
+      - set sftp:connect-program "ssh -a -x -p 18765 -i ~/.ssh/<your key>"
+      - set net:max-retries 2
+      - set net:timeout 20
+```
+
+Then the resource — two field groups, both stamped `1000`:
+
+```bash
+cd /tmp/guard-test/guard-theme
+printf '.git/\n.distignore\n' > .distignore
+printf '{"key":"group_alpha","title":"Alpha","fields":[],"modified":1000}\n' > acf-json/group_alpha.json
+printf '{"key":"group_beta","title":"Beta","fields":[],"modified":1000}\n' > acf-json/group_beta.json
+git init -q && git add -A && git commit -q -m seed
+```
+
+Run every `fdk deploy` below from `/tmp/guard-test/proj`. Outside a project directory `fdk` doesn't
+register the `deploy` command at all, and `--force` fails with `unknown option`.
+
+## The cases
+
+### 1. No remote `acf-json` yet
+
+First deploy, nothing on the server to lose.
+
+```bash
+fdk deploy
+```
+
+**Expect:** both files transfer. No warning. In particular no `Access failed: No such file` — the
+pre-flight is silenced precisely so a first deploy doesn't look like a failure.
+
+### 2. In sync
+
+```bash
+fdk deploy
+```
+
+**Expect:** the `Deploying resource` line and nothing else.
+
+### 3. Local newer — the everyday case
+
+The one that must not be blocked: a field group edited locally, on its way up.
+
+```bash
+cd /tmp/guard-test/guard-theme
+printf '{"key":"group_alpha","title":"Alpha","fields":[],"modified":2000}\n' > acf-json/group_alpha.json
+git commit -qam "local edit"
+cd /tmp/guard-test/proj && fdk deploy
+```
+
+**Expect:** `group_alpha.json` transfers. No warning.
+
+### 4. Server newer, working tree clean
+
+Rewind the local copy and commit, so the tree is clean and the server holds `2000` against the
+local `1000`.
+
+```bash
+cd /tmp/guard-test/guard-theme
+printf '{"key":"group_alpha","title":"Alpha","fields":[],"modified":1000}\n' > acf-json/group_alpha.json
+git commit -qam rewind
+git status --short          # must be empty
+cd /tmp/guard-test/proj && fdk deploy
+```
+
+**Expect:** deploy stops, naming `acf-json/group_alpha.json`, saying it has been pulled into the
+working tree. Then:
+
+```bash
+cd /tmp/guard-test/guard-theme
+git status --short                              # ` M acf-json/group_alpha.json`
+grep -o '"modified":[0-9]*' acf-json/group_alpha.json   # `"modified":2000`
+```
+
+The server's version is now an ordinary unstaged change, ready to review and commit. Nothing was
+uploaded.
+
+### 5. Server newer, and the file is dirty
+
+The refusal case: pulling would destroy uncommitted local work.
+
+```bash
+cd /tmp/guard-test/guard-theme
+printf '{"key":"group_alpha","title":"Alpha","fields":[],"modified":1500}\n' > acf-json/group_alpha.json
+cd /tmp/guard-test/proj && fdk deploy
+```
+
+**Expect:** deploy stops with `Pulling them would overwrite uncommitted local changes`, naming the
+file, and:
+
+```bash
+grep -o '"modified":[0-9]*' /tmp/guard-test/guard-theme/acf-json/group_alpha.json   # still 1500
+```
+
+The local file must be untouched. If it reads `2000`, the dirty check has failed and the guard has
+destroyed local work — that is the serious failure mode for this feature.
+
+### 6. `--force` overrides
+
+```bash
+cd /tmp/guard-test/guard-theme && git restore acf-json/group_alpha.json
+cd /tmp/guard-test/proj && fdk deploy --force
+```
+
+**Expect:** `group_alpha.json` transfers, overwriting the newer server copy. No warning.
+
+### 7. A group that exists only on the server
+
+Stands in for a field group created in production wp-admin that the repo has never seen.
+
+```bash
+cd /tmp/guard-test/guard-theme
+git rm -q acf-json/group_beta.json && git commit -qm "drop beta locally"
+cd /tmp/guard-test/proj && fdk deploy
+```
+
+**Expect:** deploy stops, naming `acf-json/group_beta.json` as pulled. Then:
+
+```bash
+cd /tmp/guard-test/guard-theme && git status --short   # `?? acf-json/group_beta.json`
+```
+
+It comes back as an untracked file rather than a modification, which is correct — the repo never had
+it.
+
+## Teardown
+
+```bash
+rm -rf /tmp/guard-test
+```
+
+Then delete the scratch directory on the server. Over SSH that is one `rm -rf` of the `path` you
+configured; over FTP, remove it in your client.
+
+## Not covered
+
+The "resource isn't a git repository" branch, which warns and declines to pull. Every resource in
+the fleet is a git repo, so there is nothing realistic to run it against.
+
+## Two traps in the harness itself
+
+Neither is caused by this change; both will stop you before you reach case 1.
+
+- **`package.json` needs a `scripts` key**, even empty. `addScriptCommands` calls `Object.keys` on
+  it unguarded, so a stub without one crashes `fdk` on startup with `Cannot convert undefined or
+  null to object`.
+- **The `ftp:` block needs a `password`, even a placeholder, when authenticating by SSH key.**
+  Without one, lftp falls back to anonymous login, drops the configured user, and fails with
+  `GetPass() failed -- assume anonymous login` followed by `Permission denied (publickey)`.

--- a/test/acf-json-guard.md
+++ b/test/acf-json-guard.md
@@ -188,14 +188,19 @@ straight over the thing the check exists to protect.
 
 ```bash
 cd /tmp/guard-test/proj
-sed 's/<your host>/nonexistent.invalid/' config.yml > config.bad.yml
-cp config.yml config.good.yml && cp config.bad.yml config.yml
+cp -f config.yml config.good.yml
+sed 's/^\( *host:\).*/\1 nonexistent.invalid/' config.good.yml > config.yml
+grep host: config.yml       # must read `nonexistent.invalid` before you go on
 fdk deploy; echo "EXIT=$?"
-cp config.good.yml config.yml
+cp -f config.good.yml config.yml
+grep host: config.yml       # and the real host must be back
 ```
 
 **Expect:** the underlying `lftp` error is printed, then `Couldn't read the 'acf-json' folder`,
 `Deploy incomplete — not uploaded: guard-theme`, and `EXIT=1`. Nothing is uploaded.
+
+Check the `grep` output rather than trusting the `sed`: if the host is unchanged this case deploys
+for real against the good config and passes with `EXIT=0`, which looks like a pass and is not one.
 
 ## Teardown
 
@@ -211,9 +216,10 @@ configured; over FTP, remove it in your client.
 The "resource isn't a git repository" branch, which warns and declines to pull. Every resource in
 the fleet is a git repo, so there is nothing realistic to run it against.
 
-## Two traps in the harness itself
+## Traps in the harness itself
 
-Neither is caused by this change; both will stop you before you reach case 1.
+None is caused by this change. The first two stop you before you reach case 1; the third lets
+case 8 pass without testing anything.
 
 - **`package.json` needs a `scripts` key**, even empty. `addScriptCommands` calls `Object.keys` on
   it unguarded, so a stub without one crashes `fdk` on startup with `Cannot convert undefined or
@@ -221,3 +227,7 @@ Neither is caused by this change; both will stop you before you reach case 1.
 - **The `ftp:` block needs a `password`, even a placeholder, when authenticating by SSH key.**
   Without one, lftp falls back to anonymous login, drops the configured user, and fails with
   `GetPass() failed -- assume anonymous login` followed by `Permission denied (publickey)`.
+- **`cp` is often aliased to `cp -i`**, which turns case 8's config swap into an interactive prompt
+  that defaults to *no*. It prints `overwrite config.yml? (y/n [n]) not overwritten` amid the
+  deploy output and is easy to miss, so the case runs against the good config. Hence the `-f` and
+  the `grep` above.


### PR DESCRIPTION
## Why

ACF writes field groups edited in wp-admin into the deployed theme's own `acf-json` directory. `fdk deploy` mirrors the local copy over it, so those edits are silently reverted by whatever deploy happens next.

This just cost us a live form. On the Hellenic Centre site, marketing rewrote the individual membership form in wp-admin in March. It worked for five months. An unrelated theme deploy on 5 August mirrored the 2023 copy back over it and the form reverted to a pre-2017 version — wrong membership tiers, wrong prices — with no warning at either end. Four membership applications came through the wrong form before the client noticed. Ten themes in the fleet ship an `acf-json` directory, so any of them can hit this.

Recovering it meant dumping `acf_get_raw_field_group` / `acf_get_raw_fields` over `wp eval-file` and hand-editing the JSON to match — about forty minutes, and only possible because that host happens to have a shell. Most don't. The server already has the file we want.

## What it does

Before mirroring, pull the remote `acf-json` down to a temp dir and compare. If the server holds a newer revision of any field group, copy those files into the working tree and stop that resource's deploy. They appear as ordinary unstaged changes: review the diff, commit, deploy again. Or `git restore` them and deploy with `--force` if the server's version is the wrong one.

No flag on the pull. Detection means the server has something we don't, and taking a copy is always the right first move.

**The comparison is by ACF's own `modified` stamp inside each group's JSON, not by file contents.** Direction is what matters, and contents can't tell you direction. Editing a field group locally also makes the two copies differ, and that is the ordinary path to a deploy — blocking it would just teach everyone to type `--force`. So:

- Group present only on the server, or its `modified` newer than the local copy's → the server is ahead → pull and stop.
- Anything else, including groups that exist only locally → an ordinary edit on its way up → deploy.
- No remote `acf-json` at all (first deploy) → nothing to lose → deploy.

Identical `modified` with differing contents deploys. That means someone hand-edited the JSON in the repo, which is deliberate; nobody hand-edits JSON over FTP.

Three cases where it declines to pull:

- **A target file has uncommitted changes.** Overwriting would destroy work git can't recover. It names the files and asks you to commit or stash first.
- **The server can't be read.** A broken pull is not the same as an empty one, and treating it as empty would deploy over the very thing being protected. The resource is skipped.
- **The resource isn't a git repository.** Nothing to undo with, so it stays out of the way and tells you to copy by hand.

A skipped resource makes the run exit non-zero, so a deploy that didn't happen can't read as success.

`--force` skips the check entirely.

The check sits above the `--backup` block, so a stopped deploy doesn't leave a stray backup folder behind and the pre-flight `lftp` call doesn't re-run the backup mirror.

## Tested

Eight cases against a throwaway resource deploying into a scratch directory — no live site involved. `test/acf-json-guard.md` has the procedure; it takes about ten minutes and needs no shell access on the server.

| Case | Result |
| --- | --- |
| No remote `acf-json` yet (first deploy) | Deploys, exit 0 |
| In sync | Deploys silently, exit 0 |
| Local `modified` newer | Deploys — the everyday case, exit 0 |
| Server `modified` newer, tree clean | Pulls the file, stops, shows as unstaged, exit 1 |
| Server `modified` newer, file dirty | Refuses to pull, leaves the local file untouched, exit 1 |
| Group only on the server | Pulls it as an untracked file, stops, exit 1 |
| Server unreachable | Skips the resource, exit 1 |
| `--force` with the server ahead | Overwrites the server, exit 0 |

The non-git-repository path is by inspection — every resource in the fleet is a git repo, so there was nothing to test it against.

Writing that procedure caught a real regression, which is the argument for keeping it: `pullRemoteAcfJson` matched `No such file or directory`, but lftp over SFTP says `Access failed: No such file (<path>)`. A missing remote folder therefore read as a broken pull, and **the first deploy of any new resource was blocked**. Now matching the half both wordings share.

## Two things worth a look

`uncommittedFiles` treats a non-zero `git status` exit as "assume there's something to lose" rather than as clean. That's deliberate: an early version passed a pathspec relative to the FDK project rather than the repo root, git exited 128, and the empty stdout read as a clean tree — so it pulled straight over a dirty file. Failing safe rather than failing quiet.

Cost is one extra `lftp` round trip per resource that has an `acf-json` directory. That directory is ~200KB on `hc`.
