### PR TITLE
Pull server-ahead acf-json into the working tree

### DIFF
--- a/index.js
+++ b/index.js
@@ -762,6 +762,24 @@ const buildResources = (project='default', task='build') => {
 	}
 }
 
+// Field groups the server holds a newer revision of, judged by ACF's own `modified` stamp.
+// Local being newer, or present only locally, is just an ordinary edit on its way up
+const acfGroupsAheadOnRemote = (remoteDir, localDir) => {
+	const modifiedStamp = file => {
+		if (!sh.test('-f', file)) { return null; }
+		try {
+			return JSON.parse(sh.cat(file).toString()).modified || 0;
+		} catch (ex) {
+			return 0;
+		}
+	};
+	return sh.ls(remoteDir).filter(file => {
+		if (!file.endsWith('.json')) { return false; }
+		const local = modifiedStamp(path.join(localDir, file));
+		return local === null || modifiedStamp(path.join(remoteDir, file)) > local;
+	});
+};
+
 // Upload resources built files to server
 const deploy = (project='default', options) => {
 	const buildIgnoreParams = (distignore) => {
@@ -822,18 +840,11 @@ const deploy = (project='default', options) => {
 					sh.rm('-rf', remoteCopy);
 					spawn(['lftp', '-c', [...commands, `mirror --verbose=0 ${path.join(destPath, name, 'acf-json')} ${remoteCopy}`].join('; ') + '; ']);
 					// no remote copy yet (first deploy): nothing to lose, carry on
-					if (sh.test('-d', remoteCopy)) {
-						// files only present locally are new field groups on their way up, not drift
-						const drift = execGet(`diff -rq ${remoteCopy} ${acfPath}`)
-							.split('\n')
-							.filter(line => line && !line.startsWith(`Only in ${acfPath}:`))
-							.map(line => line.replaceAll(remoteCopy, 'remote').replaceAll(acfPath, 'local'))
-							.join('\n');
-						sh.rm('-rf', remoteCopy);
-						if (drift) {
-							warn(`Remote 'acf-json' for '${name}' has diverged, most likely from a field group edited in wp-admin. Deploying would revert it:\n${drift}\n\nReconcile the two, or re-run with '--force' to overwrite.`);
-							continue;
-						}
+					const ahead = sh.test('-d', remoteCopy) ? acfGroupsAheadOnRemote(remoteCopy, acfPath) : [];
+					sh.rm('-rf', remoteCopy);
+					if (ahead.length > 0) {
+						warn(`Server holds newer '${name}' field groups than this repo, most likely edited in wp-admin. Deploying would revert them:\n${ahead.map(file => `  acf-json/${file}`).join('\n')}\n\nReconcile them first, or re-run with '--force' to overwrite.`);
+						continue;
 					}
 				}
 

--- a/index.js
+++ b/index.js
@@ -780,6 +780,17 @@ const acfGroupsAheadOnRemote = (remoteDir, localDir) => {
 	});
 };
 
+// Files git would lose track of if they were overwritten in place. `files` are paths
+// relative to the repository root; null means there's no repository to ask
+const uncommittedFiles = (repoPath, files) => {
+	if (sh.exec(`git -C ${repoPath} rev-parse --is-inside-work-tree`, { silent: true }).code !== 0) { return null; }
+	return files.filter(file => {
+		const status = sh.exec(`git -C ${repoPath} status --porcelain -- ${file}`, { silent: true });
+		// if git can't answer, assume there's something to lose
+		return status.code !== 0 || status.stdout.trim() !== '';
+	});
+};
+
 // Upload resources built files to server
 const deploy = (project='default', options) => {
 	const buildIgnoreParams = (distignore) => {
@@ -841,11 +852,23 @@ const deploy = (project='default', options) => {
 					spawn(['lftp', '-c', [...commands, `mirror --verbose=0 ${path.join(destPath, name, 'acf-json')} ${remoteCopy}`].join('; ') + '; ']);
 					// no remote copy yet (first deploy): nothing to lose, carry on
 					const ahead = sh.test('-d', remoteCopy) ? acfGroupsAheadOnRemote(remoteCopy, acfPath) : [];
-					sh.rm('-rf', remoteCopy);
 					if (ahead.length > 0) {
-						warn(`Server holds newer '${name}' field groups than this repo, most likely edited in wp-admin. Deploying would revert them:\n${ahead.map(file => `  acf-json/${file}`).join('\n')}\n\nReconcile them first, or re-run with '--force' to overwrite.`);
+						const listed = ahead.map(file => `  acf-json/${file}`).join('\n');
+						// bring them into the working tree so they can be reviewed and committed, but
+						// only where git can undo it and there's no local work to overwrite
+						const uncommitted = uncommittedFiles(resource, ahead.map(file => path.join('acf-json', file)));
+						if (uncommitted === null) {
+							warn(`Server holds newer '${name}' field groups than this repo, most likely edited in wp-admin. Deploying would revert them:\n${listed}\n\n'${name}' isn't a git repository, so they can't be pulled safely. Copy them across by hand, or re-run with '--force' to overwrite the server.`);
+						} else if (uncommitted.length > 0) {
+							warn(`Server holds newer '${name}' field groups than this repo, most likely edited in wp-admin:\n${listed}\n\nPulling them would overwrite uncommitted local changes. Commit or stash these first, then deploy again:\n${uncommitted.map(file => `  ${file}`).join('\n')}`);
+						} else {
+							ahead.forEach(file => sh.cp('-f', path.join(remoteCopy, file), path.join(acfPath, file)));
+							warn(`Server holds newer '${name}' field groups than this repo, most likely edited in wp-admin. Deploy stopped, and they have been pulled into the working tree:\n${listed}\n\nReview and commit them, then deploy again — or 'git restore' them and re-run with '--force' to overwrite the server.`);
+						}
+						sh.rm('-rf', remoteCopy);
 						continue;
 					}
+					sh.rm('-rf', remoteCopy);
 				}
 
 				if (options.backup) {

--- a/index.js
+++ b/index.js
@@ -814,6 +814,29 @@ const deploy = (project='default', options) => {
 				// open command
 				commands.push(`open ${url}`);
 
+				// ACF saves field groups edited in wp-admin into the deployed resource's own
+				// `acf-json`, so mirroring over it silently reverts them: check before uploading
+				const acfPath = path.join(resource, 'acf-json');
+				if (!options.force && sh.test('-d', acfPath)) {
+					const remoteCopy = path.join(sh.tempdir(), `fdk-acf-${name}`);
+					sh.rm('-rf', remoteCopy);
+					spawn(['lftp', '-c', [...commands, `mirror --verbose=0 ${path.join(destPath, name, 'acf-json')} ${remoteCopy}`].join('; ') + '; ']);
+					// no remote copy yet (first deploy): nothing to lose, carry on
+					if (sh.test('-d', remoteCopy)) {
+						// files only present locally are new field groups on their way up, not drift
+						const drift = execGet(`diff -rq ${remoteCopy} ${acfPath}`)
+							.split('\n')
+							.filter(line => line && !line.startsWith(`Only in ${acfPath}:`))
+							.map(line => line.replaceAll(remoteCopy, 'remote').replaceAll(acfPath, 'local'))
+							.join('\n');
+						sh.rm('-rf', remoteCopy);
+						if (drift) {
+							warn(`Remote 'acf-json' for '${name}' has diverged, most likely from a field group edited in wp-admin. Deploying would revert it:\n${drift}\n\nReconcile the two, or re-run with '--force' to overwrite.`);
+							continue;
+						}
+					}
+				}
+
 				if (options.backup) {
 					// copy old folder
 					const backupName = `${name}_${(new Date()).toISOString()}`;
@@ -918,6 +941,7 @@ const addProjectCommands = () => {
 		program.command('deploy [project]')
 			.description(`Deploy resources to server according to configuration in 'config.yml' file. If no <project> is passed, settings under 'default' will be loaded. Files and folders matching patterns in resource '.distignore' file will be ignored`)
 			.option('-k, --backup', 'backup existing resources folders before updating')
+			.option('-f, --force', `deploy even if the remote 'acf-json' has diverged from the local one`)
 			.action(deploy);
 	}
 	addScriptCommands();


### PR DESCRIPTION
Stacked on #58 — review that one first. Base retargets to `master` once it merges.

## Why

#58 stops a deploy that would revert field groups edited in wp-admin, but leaves you to recover them by hand. Doing that on the Hellenic Centre site meant dumping `acf_get_raw_field_group` / `acf_get_raw_fields` over `wp eval-file` and hand-editing the JSON to match — about forty minutes, and only possible because that host happens to have a shell. Most don't.

The server already has the file we want. Fetching it is one copy.

## What it does

When the check finds server-ahead groups, it copies those files into the working tree and stops the deploy. They show up as ordinary unstaged changes: review the diff, commit, deploy again. Or `git restore` them and deploy with `--force` if the server's version is the one that's wrong.

No flag. Detection means the server has something we don't, and taking a copy is always the right first move.

Two cases where it declines to pull:

- **A target file has uncommitted changes.** Overwriting would destroy work git can't recover. It names the files and asks you to commit or stash first.
- **The resource isn't a git repository.** Nothing to undo with, so it stays out of the way and tells you to copy by hand.

`--force` skips the check entirely, as before.

## Tested against `hc`

| Case | Result |
| --- | --- |
| Server ahead, tree clean | Pulls the file, stops, shows as unstaged |
| Server ahead, file dirty | Refuses to pull, names the dirty file |
| Deploy again after pulling | Proceeds normally |
| `git restore` then `--force` | Overwrites the server |

The non-git-repository path is by inspection — every resource in the fleet is a git repo, so there was nothing to test it against.

## One thing worth a look

`uncommittedFiles` treats a non-zero `git status` exit as "assume there's something to lose" rather than as clean. That's deliberate: the first version passed a pathspec relative to the FDK project rather than the repo root, git exited 128, and the empty stdout read as a clean tree — so it pulled straight over a dirty file. Failing safe rather than failing quiet.